### PR TITLE
Feature/multiple os families

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,34 @@ Documentation
 ansible-test requires that you have docker installed locally. If you are using Mac OSX, I recommend you use boot2docker.
 
 NOTE: Given docker's inflexibility with Dockerfiles, ansible-test will overwrite the Dockerfile in the current working directory from which you run ansible-test. This is currently the simplest way to integrate docker as a testing tool.
+
+Usage
+~~~~~
+
+.. code-block:: bash
+
+   usage: ansible-test [-h] [--image IMAGE] [--family {Debian,RedHat,Gentoo}]
+                       role
+
+   positional arguments:
+     role                  Role to test
+
+   optional arguments:
+     -h, --help            show this help message and exit
+     --image IMAGE, -i IMAGE
+                           Docker Base Image
+     --family {Debian,RedHat,Gentoo}, -f {Debian,RedHat,Gentoo}
+                           ansible_os_family value for Base Image
+   
+Tested image/family combinations:
+
+| image *debian:7.7* / family *Debian*  <-- default values if not specified
+| image *centos:centos7.2.1511* / family *RedHat*
+| image *gentoo-amd64-plus-portage* / family *Gentoo*
+
+Gentoo notes
+------------
+
+Rather than being able to simply pull official gentoo docker images, it was necessary to merge the stage3 and portage images to work around a docker limitation: docker currently has no way to mount volumes while building an image, only when starting up a container from an already-built image (see https://github.com/docker/docker/issues/3949 for further discussion of this limitation).
+
+See `base-images/Dockerfile.gentoo-amd64-portage <base-images/Dockerfile.gentoo-amd64-portage>`_ as example for creating base image for testing on Gentoo. This Dockerfile inherits from `gentoo/stage3-amd64 Dockerfile <https://github.com/gentoo/gentoo-docker-images/blob/master/amd64/Dockerfile>`_ and adds the commands from `gentoo/portage Dockerfile <https://github.com/gentoo/gentoo-docker-images/blob/master/portage/Dockerfile>`_ in order to create a full stage3 image with /usr/portage included rather than relying on a separage image containing a portage volume. 

--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -22,6 +22,15 @@ RUN yum install -y \
   python-pip \
   python-virtualenv \
   sudo
+{% elif family == "Gentoo" %}
+# do the 'emerge --sync' in base image, not here  -- not polite to
+# keep pulling from the rsync servers on every run of a test
+RUN emerge \
+  dev-python/pyyaml \
+  dev-python/pip \
+  dev-python/virtualenv \
+  app-admin/sudo \
+  app-portage/gentoolkit && eselect python set python2.7
 {% else %}
 RUN echo "OS family {{ family }} not yet supported, try adding it to Dockerfile.j2" ; exit 1
 {% endif %}

--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -7,6 +7,8 @@ MAINTAINER Rob McQueen
 RUN apt-get update && apt-get install -y \
   build-essential \
   libffi-dev \
+  libyaml-dev \
+  libssl-dev \
   python-dev \
   python-virtualenv \
   sudo

--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -2,22 +2,38 @@ FROM {{ image }}
 
 MAINTAINER Rob McQueen
 
-# Install Python
+# Install Ansible prerequisites
+{% if family == "Debian" %}
 RUN apt-get update && apt-get install -y \
   build-essential \
+  libffi-dev \
   python-dev \
   python-virtualenv \
-  sudo \
-  libffi-dev
+  sudo
+{% elif family == "RedHat" %}
+RUN yum install -y \
+  gcc \
+  libffi-devel \
+  libyaml-devel \
+  openssl-devel \
+  epel-release \
+  python-pip \
+  python-virtualenv \
+  sudo
+{% else %}
+RUN echo "OS family {{ family }} not yet supported, try adding it to Dockerfile.j2" ; exit 1
+{% endif %}
 
 # Install Ansible
 RUN mkdir /opt/ansible && virtualenv /opt/ansible/venv && \
-  /opt/ansible/venv/bin/pip install ansible
+  . /opt/ansible/venv/bin/activate  && \
+  pip install --upgrade setuptools && \ 
+  pip install ansible 
 
 ADD . /build
 COPY .ansible-test /build
 WORKDIR /build
 
-CMD /opt/ansible/venv/bin/ansible-playbook -i inventory.yml \
+CMD . /opt/ansible/venv/bin/activate && ansible-playbook -i inventory.yml \
     -c local -s -e testing=true -e role=$DOCKER_TEST_ROLE \
     {{ extra_args| join(" ") }} playbook.yml; /bin/bash

--- a/base-images/Dockerfile.gentoo-amd64-portage
+++ b/base-images/Dockerfile.gentoo-amd64-portage
@@ -1,0 +1,12 @@
+FROM gentoo/stage3-amd64
+
+MAINTAINER SJLC
+
+ADD http://distfiles.gentoo.org/snapshots/portage-latest.tar.bz2 /
+
+
+RUN mkdir -p /usr
+RUN bzcat /portage-latest.tar.bz2 | tar -xf - -C /usr
+RUN mkdir -p /usr/portage/distfiles /usr/portage/metadata /usr/portage/packages
+
+VOLUME /usr/portage

--- a/bin/ansible-test
+++ b/bin/ansible-test
@@ -48,11 +48,15 @@ if __name__ == "__main__":
     parser.add_argument("role", help="Role to test")
     parser.add_argument("--image", "-i", default="debian:stable",
                         help="Docker Base Image")
+    parser.add_argument("--family", "-f", default="Debian",
+                        help="ansible_os_family value for Base Image")
+
 
     args, extra_args = parser.parse_known_args()
 
     context = {
        'image': args.image,
+       'family': args.family,
        'extra_args': extra_args
     }
 

--- a/bin/ansible-test
+++ b/bin/ansible-test
@@ -49,6 +49,7 @@ if __name__ == "__main__":
     parser.add_argument("--image", "-i", default="debian:stable",
                         help="Docker Base Image")
     parser.add_argument("--family", "-f", default="Debian",
+                        choices=["Debian", "RedHat", "Gentoo"], 
                         help="ansible_os_family value for Base Image")
 
 


### PR DESCRIPTION
Support RedHat and Gentoo as ansible_os_family in addition to Debian.

Tested image/family combinations:

image _debian:7.7_ / family _Debian_  <-- default values if not specified
image _centos:centos7.2.1511_ / family _RedHat_
image _gentoo-amd64-portage_ / family _Gentoo_ <- Dockerfile used to create base image included
