### PR TITLE
ansible has deprecated 'sudo', use 'become'

### DIFF
--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -16,6 +16,6 @@ ADD . /build
 COPY .ansible-test /build
 WORKDIR /build
 
-CMD /opt/ansible/venv/bin/ansible-playbook -i inventory.yml \
-    -c local -s -e testing=true -e role=$DOCKER_TEST_ROLE \
+CMD . /opt/ansible/venv/bin/activate && ansible-playbook -i inventory.yml \
+    -c local -e testing=true -e role=$DOCKER_TEST_ROLE \
     {{ extra_args| join(" ") }} playbook.yml; /bin/bash

--- a/ansible_test/resources/playbook.yml
+++ b/ansible_test/resources/playbook.yml
@@ -3,6 +3,6 @@
 - name: Ansible Test Base Playbook
   connection: local
   hosts: localhost
-  sudo: yes
+  become: yes
   roles:
     - "{{ role }}"


### PR DESCRIPTION
Fixes nylas/ansible-test#2

Migrate from ansible's pre-1.9 privilege escalation mechanism
to the current mechanism:
- Switch 'sudo:' to 'become:' in playbook
- Remove '-s' from ansible-playbook command-line
