### PR TITLE
Add missing ffi.h header

### DIFF
--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -6,7 +6,8 @@ MAINTAINER Rob McQueen
 RUN apt-get update && apt-get install -y \
   python-dev \
   python-virtualenv \
-  sudo
+  sudo \
+  libffi-dev
 
 # Install Ansible
 RUN mkdir /opt/ansible && virtualenv /opt/ansible/venv && \


### PR DESCRIPTION
pycrypto requires ffi.h which can be installed via the libffi-dev package.
