### PR TITLE
Feature/stable default image

### DIFF
--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -4,6 +4,7 @@ MAINTAINER Rob McQueen
 
 # Install Python
 RUN apt-get update && apt-get install -y \
+  build-essential \
   python-dev \
   python-virtualenv \
   sudo

--- a/bin/ansible-test
+++ b/bin/ansible-test
@@ -46,7 +46,7 @@ def main(context):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("role", help="Role to test")
-    parser.add_argument("--image", "-i", default="debian:7.7",
+    parser.add_argument("--image", "-i", default="debian:stable",
                         help="Docker Base Image")
 
     args, extra_args = parser.parse_known_args()


### PR DESCRIPTION
debian stable as default image

seems more likely for someone to be testing on current stable debian than stuck on the old stable "wheezy" release
