### PR TITLE
Update Dockerfile.j2

### DIFF
--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -4,6 +4,7 @@ MAINTAINER Rob McQueen
 
 # Install Python
 RUN apt-get update && apt-get install -y \
+  libffi-dev \
   python-dev \
   python-virtualenv \
   sudo


### PR DESCRIPTION
Adding `libffi-dev` which is a requirement to build `python-dev` re #9 
