### PR TITLE
Dependency fixes

### DIFF
--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
   python-dev \
   python-virtualenv \
   sudo \
+  libssl-dev \
   libffi-dev
 
 # Install Ansible

--- a/ansible_test/resources/Dockerfile.j2
+++ b/ansible_test/resources/Dockerfile.j2
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Ansible
 RUN mkdir /opt/ansible && virtualenv /opt/ansible/venv && \
-  /opt/ansible/venv/bin/pip install ansible
+  /opt/ansible/venv/bin/pip install -U setuptools ansible
 
 ADD . /build
 COPY .ansible-test /build

--- a/ansible_test/resources/playbook.yml
+++ b/ansible_test/resources/playbook.yml
@@ -3,6 +3,6 @@
 - name: Ansible Test Base Playbook
   connection: local
   hosts: localhost
-  sudo: yes
+  become: true
   roles:
     - "{{ role }}"


### PR DESCRIPTION
I have added libssl-dev (which is required for pycrypto/cryptography) as a dependency. I also needed an updated setuptools version to make the test run. Otherwise I get a version conflict:

```
VersionConflict: (setuptools 5.5.1 (/opt/ansible/venv/lib/python2.7/site-packages), Requirement.parse('setuptools>=11.3'))
```
